### PR TITLE
Fix: Permission interface mismatch on flutter 3 broke compile

### DIFF
--- a/android/src/main/kotlin/dev/juyoung/fitness/FitnessPlugin.kt
+++ b/android/src/main/kotlin/dev/juyoung/fitness/FitnessPlugin.kt
@@ -320,10 +320,10 @@ class FitnessPlugin : FlutterPlugin, ActivityAware, MethodCallHandler, ActivityR
         return true
     }
 
-    override fun onRequestPermissionsResult(
+     override fun onRequestPermissionsResult(
         requestCode: Int,
-        permissions: Array<out String>?,
-        grantResults: IntArray?
+        permissions: Array<out String>,
+        grantResults: IntArray
     ): Boolean {
         return when (requestCode) {
             ACTIVITY_RECOGNITION_REQUEST_CODE -> {


### PR DESCRIPTION
See https://github.com/dev-juyoung/Fitness/issues/15

I just wanted to show a fix. I'm nor sure whether you would want to keep this backwards compatible, if that's possible.